### PR TITLE
fix: クォート自動選択

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,9 @@
   "overrides": [
     {
       "files": ["**/*.tsx"],
-      "rules": { "quotes": "off" }
+      "rules": {
+        "quotes": "off"
+      }
     }
   ],
   "parser": "@typescript-eslint/parser",
@@ -39,15 +41,13 @@
     ],
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-var-requires": 0,
-    "@typescript-eslint/quotes": ["error", "double"],
+    "jsx-quotes": ["error", "prefer-double"],
     "prettier/prettier": [
       "error",
       {
         "endOfLine": "auto"
       }
     ],
-    "quotes": ["error", "single"],
-    "jsx-quotes": ["error", "prefer-double"],
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off"
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,31 +1,54 @@
 {
- "env": {
-  "browser": true,
-  "es2021": true
- },
- "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:@typescript-eslint/recommended", "plugin:@typescript-eslint/eslint-recommended", "plugin:@typescript-eslint/recommended", "plugin:react/recommended", "plugin:prettier/recommended", "next/core-web-vitals", "eslint-config-prettier"],
- "overrides": [],
- "parser": "@typescript-eslint/parser",
- "parserOptions": {
-  "ecmaVersion": "latest",
-  "sourceType": "module"
- },
- "plugins": ["react", "@typescript-eslint"],
- "rules": {
-  "@typescript-eslint/no-unused-vars": "off",
-  "react/jsx-uses-react": "off",
-  "react/react-in-jsx-scope": "off",
-  "@next/next/no-img-element": "off",
-  "@typescript-eslint/ban-types": [
-   "error",
-   {
-    "extendDefaults": true,
-    "types": {
-     "{}": false
-    }
-   }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "plugin:prettier/recommended",
+    "next/core-web-vitals",
+    "eslint-config-prettier"
   ],
-  "@typescript-eslint/no-var-requires": 0,
-  "prettier/prettier": ["error", { "endOfLine": "auto" }]
- }
+  "overrides": [
+    {
+      "files": ["**/*.tsx"],
+      "rules": { "quotes": "off" }
+    }
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint"],
+  "rules": {
+    "@next/next/no-img-element": "off",
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "extendDefaults": true,
+        "types": {
+          "{}": false
+        }
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-var-requires": 0,
+    "@typescript-eslint/quotes": ["error", "double"],
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
+    "quotes": ["error", "single"],
+    "jsx-quotes": ["error", "prefer-double"],
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off"
+  }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,23 +1,3 @@
 {
-	"overrides": [
-		{
-			"files": [
-				"**/*.css",
-				"**/*.scss",
-				"**/*.html"
-			],
-			"options": {
-				"singleQuote": true
-			}
-		},
-		{
-			"files": [
-				"**/*.tsx",
-				"**/*.jsx"
-			],
-			"options": {
-				"singleQuote": false
-			}
-		}
-	]
+	"singleQuote": false
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,23 @@
+{
+	"overrides": [
+		{
+			"files": [
+				"**/*.css",
+				"**/*.scss",
+				"**/*.html"
+			],
+			"options": {
+				"singleQuote": true
+			}
+		},
+		{
+			"files": [
+				"**/*.tsx",
+				"**/*.jsx"
+			],
+			"options": {
+				"singleQuote": false
+			}
+		}
+	]
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,9 +1,9 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
-    'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
-    'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
+  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+    "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
+    "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -51,7 +51,9 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition: background 200ms, border 200ms;
+  transition:
+    background 200ms,
+    border 200ms;
 }
 
 .card span {


### PR DESCRIPTION
css, scss, htmlはシングルクォートを、
tsx, jsxはダブルクォートを使用するように
prettierの設定およびeslintの設定を修正

Closes #<issue No.>

### 変更内容
- .prettierrc.jsonと.eslintrc.jsonの修正

### 次回以降の PR でやるべきこと
-
